### PR TITLE
Dockerfile: Fix checked-out branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV PHP_MEMORY_LIMIT 256M
 ENV MAX_UPLOAD 128M
 ENV PSM_DB_PORT 3306
 ENV UPDATE_INTERVAL 300
+ENV PHPSERVERMON_VER v3.2.2
 
 RUN mkdir /logs /run/nginx
 
@@ -15,6 +16,7 @@ RUN apk add --no-cache --update libxml2-dev curl-dev supervisor nginx curl git \
 	&& docker-php-ext-install mysqli pdo_mysql curl xml sockets \
 	&& rm -rf /var/www/* \
     && git clone https://github.com/phpservermon/phpservermon.git ./ \
+    && git checkout tags/$PHPSERVERMON_VER \
     && php composer.phar install \
     && rm -rf Makefile Vagrantfile composer* .git \
     && apk del --purge git libxml2-dev curl-dev


### PR DESCRIPTION
As is, your dockerfile pulls the latest development branch, rather
than the last stable release. This patch:

  - adds an environment variable which can be used to easily change
    the pulled version (specifiying the tagged release)
  - Adds the command to `git checkout tags/<tag>`

Signed-off-by: Mark Stenglein <mark@stengle.in>